### PR TITLE
Adding extended variables for SMTP email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ NODE_ENV=development
 
 APP_NAME=AdonisJs
 APP_URL=http://${HOST}:${PORT}
+EXTERNAL_DOMAIN=ferdi.domain.tld
 
 CACHE_VIEWS=false
 
@@ -29,3 +30,4 @@ SMTP_HOST=127.0.0.1
 MAIL_USERNAME=username
 MAIL_PASSWORD=password
 MAIL_SENDER=noreply@getferdi.com
+SSL=false

--- a/config/mail.js
+++ b/config/mail.js
@@ -31,7 +31,7 @@ module.exports = {
     port: Env.get('SMTP_PORT', 2525),
     host: Env.get('SMTP_HOST'),
     secure: Env.get('SSL', false), // true for 465, false for other ports,
-    authMethod: ‘LOGIN’,
+    authMethod: 'LOGIN',
     auth: {
       user: Env.get('MAIL_USERNAME'),
       pass: Env.get('MAIL_PASSWORD')

--- a/config/mail.js
+++ b/config/mail.js
@@ -21,13 +21,17 @@ module.exports = {
   |
   | Here we define configuration for sending emails via SMTP.
   |
+  | https://nodemailer.com/smtp/
+  |
   */
   smtp: {
     driver: 'smtp',
     pool: true,
+    name: Env.get('EXTERNAL_DOMAIN'),
     port: Env.get('SMTP_PORT', 2525),
     host: Env.get('SMTP_HOST'),
-    secure: false,
+    secure: Env.get('SSL', false), // true for 465, false for other ports,
+    authMethod: ‘LOGIN’,
     auth: {
       user: Env.get('MAIL_USERNAME'),
       pass: Env.get('MAIL_PASSWORD')


### PR DESCRIPTION
This PR adds a few variables to the .env.example and mail.js in order to try to get SMTP sending functioning with a broader range of SMTP mail providers. 