### PR TITLE
Send correct Content-Type header for custom icon

### DIFF
--- a/app/Controllers/Http/ServiceController.js
+++ b/app/Controllers/Http/ServiceController.js
@@ -142,6 +142,7 @@ class ServiceController {
         iconId = uuid() + uuid();
       // eslint-disable-next-line no-await-in-loop
       } while (await fs.exists(path.join(Helpers.tmpPath('uploads'), iconId)));
+      iconId = `${iconId}.${icon.extname}`;
 
       await icon.move(Helpers.tmpPath('uploads'), {
         name: iconId,


### PR DESCRIPTION
Saving the custom icon without an extension makes it so that the `response.download` call won't give it a proper Content-Type, so it won't be rendered correctly.

This is related to:
- getferdi/ferdi#1532
- getferdi/ferdi#1475
- getferdi/ferdi#1152
- getferdi/ferdi#780
- getferdi/ferdi#470
- getferdi/recipes#422