### PR TITLE
Removed references to png images since they were not being used anyways.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To add your recipe to ferdi-server, open `http://[YOUR FERDI-SERVER]/new` in you
 - `Author`: Author who created the recipe
 - `Name`: Name for your new service. Can contain spaces and unicode characters
 - `Service ID`: Unique ID for this recipe. Does not contain spaces or special characters (e.g. `google-drive`)
-- `Link to PNG/SVG image`: Direct link to a 1024x1024 PNG image and SVG that is used as a logo inside the store. Please use jsDelivr when using a file uploaded to GitHub as raw.githubusercontent files won't load
+- `Link to SVG image`: Direct link to a 1024x1024 SVG that is used as a logo inside the store. Please use jsDelivr when using a file uploaded to GitHub as raw.githubusercontent files won't load
 - `Recipe files`: Recipe files that you created using the [Franz recipe creation guide](https://github.com/meetfranz/plugins/blob/master/docs/integration.md). Please do *not* package your files beforehand - upload the raw files (you can drag and drop multiple files). ferdi-server will automatically package and store the recipe in the right format. Please also do not drag and drop or select the whole folder, select the individual files.
 
 ### Listing custom recipes

--- a/app/Controllers/Http/RecipeController.js
+++ b/app/Controllers/Http/RecipeController.js
@@ -61,7 +61,6 @@ class RecipeController {
       name: 'required|string',
       id: 'required|unique:recipes,recipeId',
       author: 'required|accepted',
-      png: 'required|url',
       svg: 'required|url',
     });
     if (validation.fails()) {
@@ -108,7 +107,6 @@ class RecipeController {
         featured: false,
         version: '1.0.0',
         icons: {
-          png: data.png,
           svg: data.svg,
         },
       }),

--- a/resources/views/others/new.edge
+++ b/resources/views/others/new.edge
@@ -14,9 +14,6 @@
   <label for="id">Service ID</label><br />
   <input type="text" name="id" placeholder="sample-service" required><br />
 
-  <label for="png">Link to PNG image*</label><br />
-  <input type="text" name="png" placeholder="https://.../logo.png" required><br />
-
   <label for="svg">Link to SVG image*</label><br />
   <input type="text" name="svg" placeholder="https://.../logo.svg" required><br />
   *These images must be publicly availible and have CORS enabled in order to work.<br /><br />


### PR DESCRIPTION
While researching [this discussion](https://github.com/getferdi/ferdi/discussions/1601), I chanced upon the fact that Ferdi does not depend on the `*.png` images (maybe it did at an earlier date).
By removing the remaining methods that reference the png image files, we can then safely remove the images themselves in the recipes, thus making the final installer file smaller in size while also removing dead code.