### PR TITLE
Update custom service icon host and protocol and fix smtp mailer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,7 @@ PORT=3333
 NODE_ENV=development
 
 APP_NAME=Ferdi-server
-APP_URL=http://${HOST}:${PORT}
-EXTERNAL_DOMAIN=ferdi.domain.tld
+EXTERNAL_DOMAIN=https://ferdi.domain.tld
 
 CACHE_VIEWS=false
 

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ PORT=3333
 NODE_ENV=development
 
 APP_NAME=Ferdi-server
-EXTERNAL_DOMAIN=https://ferdi.domain.tld
+APP_URL=localhost
 
 CACHE_VIEWS=false
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,13 +21,14 @@ jobs:
         with:
           images: |
             getferdi/ferdi-server
-#            ghcr.io/getferdi/ferdi-server
+            ghcr.io/getferdi/ferdi-server
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+          labels: org.opencontainers.image.title=Ferdi-server
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After setting up the docker container we recommend you set up an NGINX reverse p
 	    -e DB_DATABASE=<yourdbdatabase> \
 	    -e DB_SSL=false \
 	    -e MAIL_CONNECTION=smtp \
-	    -e SMPT_HOST=<smtpmailserver> \
+	    -e SMTP_HOST=<smtpmailserver> \
 	    -e SMTP_PORT=<smtpport> \
 	    -e MAIL_SSL=true/false \
 	    -e MAIL_USERNAME=<yourmailusername> \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After setting up the docker container we recommend you set up an NGINX reverse p
 	    docker create \
 	    --name=ferdi-server \
 	    -e NODE_ENV=development \
-	    -e EXTERNAL_DOMAIN=https://<ferdi-serverdomain> \
+	    -e APP_URL=<ferdi-server-url> \
 	    -e DB_CONNECTION=<database> \
 	    -e DB_HOST=<yourdbhost> \
 	    -e DB_PORT=<yourdbport> \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After setting up the docker container we recommend you set up an NGINX reverse p
 	    docker create \
 	    --name=ferdi-server \
 	    -e NODE_ENV=development \
-	    -e EXTERNAL_DOMAIN=<ferdi-serverdomain> \
+	    -e EXTERNAL_DOMAIN=https://<ferdi-serverdomain> \
 	    -e DB_CONNECTION=<database> \
 	    -e DB_HOST=<yourdbhost> \
 	    -e DB_PORT=<yourdbport> \

--- a/app/Controllers/Http/ServiceController.js
+++ b/app/Controllers/Http/ServiceController.js
@@ -98,7 +98,7 @@ class ServiceController {
         workspaces: [],
         ...settings,
         iconUrl: settings.iconId
-          ? `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`
+          ? `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`
           : null,
         id: service.serviceId,
         name: service.name,
@@ -176,7 +176,7 @@ class ServiceController {
           id,
           name: service.name,
           ...newSettings,
-          iconUrl: `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${newSettings.iconId}`,
+          iconUrl: `${Env.get('APP_URL')}/v1/icon/${newSettings.iconId}`,
           userId: auth.user.id,
         },
         status: ['updated'],
@@ -223,7 +223,7 @@ class ServiceController {
         id,
         name: service.name,
         ...settings,
-        iconUrl: `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`,
+        iconUrl: `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`,
         userId: auth.user.id,
       },
       status: ['updated'],
@@ -293,7 +293,7 @@ class ServiceController {
         workspaces: [],
         ...settings,
         iconUrl: settings.iconId
-          ? `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`
+          ? `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`
           : null,
         id: service.serviceId,
         name: service.name,

--- a/app/Controllers/Http/ServiceController.js
+++ b/app/Controllers/Http/ServiceController.js
@@ -98,7 +98,7 @@ class ServiceController {
         workspaces: [],
         ...settings,
         iconUrl: settings.iconId
-          ? `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`
+          ? `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`
           : null,
         id: service.serviceId,
         name: service.name,
@@ -176,7 +176,7 @@ class ServiceController {
           id,
           name: service.name,
           ...newSettings,
-          iconUrl: `${Env.get('APP_URL')}/v1/icon/${newSettings.iconId}`,
+          iconUrl: `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${newSettings.iconId}`,
           userId: auth.user.id,
         },
         status: ['updated'],
@@ -223,7 +223,7 @@ class ServiceController {
         id,
         name: service.name,
         ...settings,
-        iconUrl: `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`,
+        iconUrl: `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`,
         userId: auth.user.id,
       },
       status: ['updated'],
@@ -293,7 +293,7 @@ class ServiceController {
         workspaces: [],
         ...settings,
         iconUrl: settings.iconId
-          ? `${Env.get('APP_URL')}/v1/icon/${settings.iconId}`
+          ? `${Env.get('EXTERNAL_DOMAIN')}/v1/icon/${settings.iconId}`
           : null,
         id: service.serviceId,
         name: service.name,

--- a/config/mail.js
+++ b/config/mail.js
@@ -25,7 +25,7 @@ module.exports = {
   smtp: {
     driver: 'smtp',
     pool: true,
-    name: Env.get('EXTERNAL_DOMAIN'),
+    name: Env.get('APP_URL'),
     port: Env.get('SMTP_PORT', '2525'),
     host: Env.get('SMTP_HOST', 'localhost'),
     secure: JSON.parse(Env.get('MAIL_SSL', 'false')),

--- a/config/mail.js
+++ b/config/mail.js
@@ -26,9 +26,9 @@ module.exports = {
     driver: 'smtp',
     pool: true,
     name: Env.get('EXTERNAL_DOMAIN'),
-    port: Env.get('SMTP_PORT', 2525),
-    host: Env.get('SMTP_HOST'),
-    secure: JSON.parse(Env.get('MAIL_SSL', Env.get('SSL', false))),
+    port: Env.get('SMTP_PORT', '2525'),
+    host: Env.get('SMTP_HOST', 'localhost'),
+    secure: JSON.parse(Env.get('MAIL_SSL', 'false')),
     authMethod: 'LOGIN',
     auth: {
       user: Env.get('MAIL_USERNAME'),

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ To create the docker container with the proper parameters:
 	  -e DB_DATABASE=<yourdbdatabase> \
 	  -e DB_SSL=false \
 	  -e MAIL_CONNECTION=smtp \
-	  -e SMPT_HOST=<smtpmailserver> \
+	  -e SMTP_HOST=<smtpmailserver> \
 	  -e SMTP_PORT=<smtpport> \
 	  -e MAIL_SSL=true/false \
 	  -e MAIL_USERNAME=<yourmailusername> \
@@ -88,7 +88,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e DB_DATABASE=<databasename>` | for specifying the database name to be used, default is ferdi |
 | `-e DB_SSL=false` | true only if your database is postgres and it is hosted online, on platforms like GCP, AWS, etc |
 | `-e MAIL_CONNECTION=<mailsender>` | for specifying the mail sender to be used, default is smtp |
-| `-e SMPT_HOST=<smtpmailserver>` | for specifying the mail host to be used, default is 127.0.0.1 |
+| `-e SMTP_HOST=<smtpmailserver>` | for specifying the mail host to be used, default is 127.0.0.1 |
 | `-e SMTP_PORT=<smtpport>` | for specifying the mail port to be used, default is 2525 |
 | `-e MAIL_SSL=true/false` | for specifying SMTP mail security, default is false |
 | `-e MAIL_USERNAME=<yourmailusername>` | for specifying your mail username to be used, default is username |

--- a/docker/README.md
+++ b/docker/README.md
@@ -79,7 +79,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | :----: | --- |
 | `-p <port>:3333` | Will map the container's port 3333 to a port on the host, default is 3333. See the [Docker docs](https://docs.docker.com/config/containers/container-networking/) for more information about port mapping |
 | `-e NODE_ENV=development` | for specifying Node environment, production or development, default is development **currently this should not be changed**. See the [Docker docs](https://docs.docker.com/) for more information on the use of environmental variables in [Command-line](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only) and [Docker Compose](https://docs.docker.com/compose/environment-variables/) |
-| `-e EXTERNAL_DOMAIN=<ferdi-serverdomain>` | for specifying the external domain address of the Ferdi-server |
+| `-e EXTERNAL_DOMAIN=https://<ferdi-serverdomain>` | for specifying the external https domain address of the Ferdi-server |
 | `-e DB_CONNECTION=<databasedriver` | for specifying the database being used, default is sqlite, see [below](#supported-databases-and-drivers) for other options |
 | `-e DB_HOST=<yourdbhost>` | for specifying the database host, default is 127.0.0.1 |
 | `-e DB_PORT=<yourdbport>` | for specifying the database port, default is 3306 |

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,7 @@ To create the docker container with the proper parameters:
 	docker create \
 	  --name=ferdi-server \
 	  -e NODE_ENV=development \
-	  -e EXTERNAL_DOMAIN=https://<ferdi-serverdomain> \
+	  -e APP_URL=<ferdi-server-url> \
 	  -e DB_CONNECTION=<database> \
 	  -e DB_HOST=<yourdbhost> \
 	  -e DB_PORT=<yourdbport> \
@@ -79,7 +79,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | :----: | --- |
 | `-p <port>:3333` | Will map the container's port 3333 to a port on the host, default is 3333. See the [Docker docs](https://docs.docker.com/config/containers/container-networking/) for more information about port mapping |
 | `-e NODE_ENV=development` | for specifying Node environment, production or development, default is development **currently this should not be changed**. See the [Docker docs](https://docs.docker.com/) for more information on the use of environmental variables in [Command-line](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only) and [Docker Compose](https://docs.docker.com/compose/environment-variables/) |
-| `-e EXTERNAL_DOMAIN=https://<ferdi-serverdomain>` | for specifying the external https domain address of the Ferdi-server |
+| `-e APP_URL=<ferdi-server-url>` | for specifying the URL of the Ferdi-server, including `http://` or `https://` as relevant. |
 | `-e DB_CONNECTION=<databasedriver` | for specifying the database being used, default is sqlite, see [below](#supported-databases-and-drivers) for other options |
 | `-e DB_HOST=<yourdbhost>` | for specifying the database host, default is 127.0.0.1 |
 | `-e DB_PORT=<yourdbport>` | for specifying the database port, default is 3306 |

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,7 @@ To create the docker container with the proper parameters:
 	docker create \
 	  --name=ferdi-server \
 	  -e NODE_ENV=development \
-	  -e EXTERNAL_DOMAIN=<ferdi-serverdomain> \
+	  -e EXTERNAL_DOMAIN=https://<ferdi-serverdomain> \
 	  -e DB_CONNECTION=<database> \
 	  -e DB_HOST=<yourdbhost> \
 	  -e DB_PORT=<yourdbport> \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: ferdi-server
     environment:
       - NODE_ENV=development
-      - EXTERNAL_DOMAIN=localhost
+      - APP_URL=localhost
       - DB_CONNECTION=sqlite
       - DB_HOST=127.0.0.1
       - DB_PORT=3306

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - DB_DATABASE=ferdi
       - DB_SSL=false
       - MAIL_CONNECTION=smtp
-      - SMPT_HOST=127.0.0.1
+      - SMTP_HOST=127.0.0.1
       - SMTP_PORT=2525
       - MAIL_SSL=false
       - MAIL_USERNAME=username

--- a/start/events.js
+++ b/start/events.js
@@ -5,8 +5,8 @@ const Env = use('Env');
 Event.on('forgot::password', async ({ user, token }) => {
   const body = `
 Hello ${user.username},
-we just received a request to reset your password of your Ferdi account.
-Use the link below to reset your password. If you havn't requested this, please ignore this message.
+we received a request to reset your Ferdi account password.
+Use the link below to reset your password. If you didn't requested that your password be reset, please ignore this message.
 
 ${Env.get('EXTERNAL_DOMAIN')}/user/reset?token=${encodeURIComponent(token)}
 

--- a/start/events.js
+++ b/start/events.js
@@ -5,7 +5,7 @@ const Env = use('Env');
 Event.on('forgot::password', async ({ user, token }) => {
   const body = `
 Hello ${user.username},
-we just recieved a request to reset your password of your Ferdi account.
+we just received a request to reset your password of your Ferdi account.
 Use the link below to reset your password. If you havn't requested this, please ignore this message.
 
 ${Env.get('EXTERNAL_DOMAIN')}/user/reset?token=${encodeURIComponent(token)}

--- a/start/events.js
+++ b/start/events.js
@@ -8,7 +8,7 @@ Hello ${user.username},
 we just recieved a request to reset your password of your Ferdi account.
 Use the link below to reset your password. If you havn't requested this, please ignore this message.
 
-${Env.get('APP_URL')}/user/reset?token=${encodeURIComponent(token)}
+${Env.get('EXTERNAL_DOMAIN')}/user/reset?token=${encodeURIComponent(token)}
 
 This message was sent automatically. Please do not reply.
 `;

--- a/start/events.js
+++ b/start/events.js
@@ -8,7 +8,7 @@ Hello ${user.username},
 we received a request to reset your Ferdi account password.
 Use the link below to reset your password. If you didn't requested that your password be reset, please ignore this message.
 
-${Env.get('EXTERNAL_DOMAIN')}/user/reset?token=${encodeURIComponent(token)}
+${Env.get('APP_URL')}/user/reset?token=${encodeURIComponent(token)}
 
 This message was sent automatically. Please do not reply.
 `;


### PR DESCRIPTION
Removed the `APP_URL` variable in favour of `EXTERNAL_DOMAIN` and specified that `https://` should be in included in this variable. This is meant to fix problems users were having with custom service icons and problems with the `Forgot Password` mail process. 

Related to https://github.com/getferdi/server/issues/79