### PR TITLE
fix(dockerfile): Healthcheck parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN ["apk", "add", "--no-cache", "sqlite-libs", "curl", "su-exec"]
 COPY --from=build /server-build /app
 RUN ["npm", "i", "-g", "@adonisjs/cli"]
 
-HEALTHCHECK --interval=5m --timeout=3s CMD curl -sSf http://localhost:${PORT}/health
+HEALTHCHECK --start-period=5s --interval=30s --retries=5 --timeout=3s CMD curl -sSf http://localhost:${PORT}/health
 
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/.env /app/.env


### PR DESCRIPTION
## Current behaviour

**TL;DR:** Container is taking 5 minutes before being healthy

Docker is checking health of the container 0 second after the start ([default value](https://docs.docker.com/engine/reference/builder/#healthcheck) and then every 5 minutes, so 5 minutes later and 10 minutes later. 

After 0 second, the service is, of course, not ready. So the healthcheck realisticly waits for 5 minutes before trying to check if the container is healthy.

This affects traefik reverse-proxy based servers, as it relates on the healthcheck if it exists, meaning that ferdi server takes 5 minutes before being available


## New behaviour

**TL;DR:** Container is now taking 5 seconds before being healthy for 99% of setups, and more for the 1% left

(The values are a proposal, may be changed)

Now Docker waits for 5 seconds before checking container's health, which should be enough for 99% of the setups, and will retry after 30 seconds 4 more times if health check fails (with a maximum of 2 minutes and 5 seconds, which should be enough for the 1% left)

## How to test

You can try with `docker run eggermont/ferdi-server:2021-12-19` ([link to Docker Hub](https://hub.docker.com/r/eggermont/ferdi-server)) and making a `docker ps` to see container's health.